### PR TITLE
[Service Worker] add caches to service worker install event

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,6 +1,25 @@
+const cacheName = 'v1';
+
+const cacheAssets = [
+    'index.html',
+    '/',
+    'styles.css',
+    'app.js'
+];
+
 // Call install event
 self.addEventListener('install', e => {
     console.log('[Service Worker Installed]');
+
+    e.waitUntil(
+        caches
+            .open(cacheName)
+            .then(cache => {
+                console.log('[Service worker is Caching...]');
+                cache.addAll(cacheAssets);
+            })
+            .then(() => self.skipWaiting())
+    );
 });
 
 // Call Activate Event


### PR DESCRIPTION
Problem
 * Service worker install event doesn't caches assets yet

Solution
 * Call the event dot waitUntil() then add cacheVersion name to add all cache
 * Method implemented to do the statement above. Literally service worker is caching pages

[Finishes]